### PR TITLE
feat: adding some sweet sweet mobile talk padding

### DIFF
--- a/src/pages/talks/[talk]/index.astro
+++ b/src/pages/talks/[talk]/index.astro
@@ -99,6 +99,9 @@ const metaDescription = talkDescription.join(" ");
     flex-direction: column;
     align-items: center;
     gap: var(--Padding-l);
+    @media (max-width: 700px) {
+      padding: 0 var(--Padding-talk);
+    }
   }
 
   section {
@@ -134,6 +137,7 @@ const metaDescription = talkDescription.join(" ");
       max-width: 649px;
       padding: 0;
       padding-top: var(--Padding-xl);
+      padding-left: var(--Padding-rem)
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,7 @@
   --Padding-xxl: 8rem;
   --Padding-index: var(--Padding-rem);
   --Padding-practical: 4.5rem;
+  --Padding-talk: var(--Padding-rem);
 
   --Font-size-H1: 4.5rem;
   --Font-size-H2: 3.5rem;


### PR DESCRIPTION
Cool to see a nice Astro site in the wild! 🙌 

Proposing to turn this:

<img width="392" alt="image" src="https://github.com/user-attachments/assets/c8f9c165-057c-413e-9ec2-39848097a235" />

into this:

<img width="391" alt="image" src="https://github.com/user-attachments/assets/720d3624-d747-41dd-a5eb-e89336e77631" />

You can of course consider to do something else with the arrow padding and/or change the breakpoints, this is quick and dirty 🫣 